### PR TITLE
added testing for password validation closes #3

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -115,14 +115,14 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str = Field(
         ...,
-        min_length=8,
+        min_length=12,
         description="A strong password for the user's account. Must be at least 8 characters long and include uppercase and lowercase letters, a digit, and a special character.",
         example="SecurePassword123!"
     )
 
     @validator('password')
     def validate_password(cls, v):
-        if len(v) < 8:
+        if len(v) < 12:
             raise ValueError("Password must be at least 8 characters long.")
         if not re.search(r"[A-Z]", v):
             raise ValueError("Password must contain at least one uppercase letter.")

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -111,3 +111,26 @@ def test_user_base_username_invalid(username, user_base_data):
     user_base_data["username"] = username
     with pytest.raises(ValidationError):
         UserBase(**user_base_data)
+
+# Tests for password validation
+@pytest.mark.parametrize("password", [
+    "Str0ngP@ssw0rd!",  # Strong password with mix of uppercase, lowercase, numbers, and special characters
+    "G00dPassword!"
+])
+def test_user_create_password_valid(password, user_create_data):
+    user_create_data["password"] = password
+    user = UserCreate(**user_create_data)
+    assert user.password == password
+
+@pytest.mark.parametrize("password", [
+    "a" * 11,  # Password shorter than minimum allowed length
+    "password",  # Password without uppercase letters
+    "PASSWORD",  # Password without lowercase letters
+    "Password",  # Password without numbers
+    "Password123",  # Password without special characters
+    "p@ssw0rd",  # Password shorter than minimum allowed length, even with complexity
+])
+def test_user_create_password_invalid(password, user_create_data):
+    user_create_data["password"] = password
+    with pytest.raises(ValidationError):
+        UserCreate(**user_create_data)


### PR DESCRIPTION
Added testing to ensure password is of required length, and includes a special character, uppercase and lowercase letters and numbers. Updated user schema to require password length of 12, instead of 8.